### PR TITLE
[WIP] Add a Custom size option to the Embed option.

### DIFF
--- a/__tests__/MiradorShareDialog.test.js
+++ b/__tests__/MiradorShareDialog.test.js
@@ -10,6 +10,7 @@ function createWrapper(props) {
       displayShareLink
       manifestId="http://example.com/abc/iiif/manifest"
       open
+      windowId="wid123"
 
       {...props}
     />,

--- a/__tests__/MiradorShareEmbed.test.js
+++ b/__tests__/MiradorShareEmbed.test.js
@@ -8,6 +8,8 @@ function createWrapper(props) {
     <MiradorShareEmbed
       embedUrlReplacePattern={[]}
       manifestId="https://example.com/abc123/iiif/manifest"
+      windowId="wid123"
+
       {...props}
     />,
   ).dive();
@@ -47,13 +49,13 @@ describe('MiradorShareEmbed', () => {
   it('renders the embed code in a text field', () => {
     wrapper = createWrapper();
 
-    expect(wrapper.find('TextField').props().value).toMatch(/^<iframe .*/);
+    expect(wrapper.find('TextField[multiline]').props().value).toMatch(/^<iframe .*/);
   });
 
   it('has a copy button that uses the CopyToClipboard library', () => {
     wrapper = createWrapper();
 
-    expect(wrapper.find('WithStyles(Button)').props().children).toEqual('Copy');
+    expect(wrapper.find('WithStyles(Button)[children="Copy"]').length).toEqual(1);
     expect(wrapper.find('CopyToClipboard').props().text).toMatch(/^<iframe .*/);
   });
 
@@ -64,7 +66,7 @@ describe('MiradorShareEmbed', () => {
     ];
     wrapper = createWrapper({ embedUrlReplacePattern });
 
-    expect(wrapper.find('TextField').props().value).toEqual(
+    expect(wrapper.find('TextField[multiline]').props().value).toEqual(
       '<iframe src="https://embed.example.com/embed?url=https://example.com/abc123" width="560" height="420" allowfullscreen frameborder="0" />',
     );
   });
@@ -73,9 +75,9 @@ describe('MiradorShareEmbed', () => {
     wrapper = createWrapper();
 
     expect(wrapper.state().selectedSize).toEqual('small');
-    expect(wrapper.find('TextField').props().value).toMatch(/width="560" height="420"/);
+    expect(wrapper.find('TextField[multiline]').props().value).toMatch(/width="560" height="420"/);
     wrapper.setState({ selectedSize: 'large' });
-    expect(wrapper.find('TextField').props().value).toMatch(/width="800" height="600"/);
+    expect(wrapper.find('TextField[multiline]').props().value).toMatch(/width="800" height="600"/);
   });
 
   it('switching the selected radio updates state', () => {
@@ -84,5 +86,47 @@ describe('MiradorShareEmbed', () => {
     expect(wrapper.state().selectedSize).toEqual('small');
     wrapper.find('RadioGroup').simulate('change', { target: { value: 'large' } });
     expect(wrapper.state().selectedSize).toEqual('large');
+  });
+
+  describe('Custom Size Option', () => {
+    it('renders a custom size button', () => {
+      wrapper = createWrapper();
+
+      expect(wrapper.find('RadioGroup WithStyles(Button) WithStyles(Typography)').props().children).toEqual('Custom');
+      expect(wrapper.find('RadioGroup WithStyles(Button) TextField[defaultValue="1024"]').length).toEqual(1);
+      expect(wrapper.find('RadioGroup WithStyles(Button) TextField[defaultValue="768"]').length).toEqual(1);
+    });
+
+    it('sets the size to custom when the Button is clicked', () => {
+      wrapper = createWrapper();
+
+      expect(wrapper.state().selectedSize).toEqual('small');
+      wrapper.find('RadioGroup WithStyles(Button)').simulate('click');
+      expect(wrapper.state().selectedSize).toEqual('custom');
+    });
+
+    it('has disabled the text fields unless the Custom option was selected', () => {
+      wrapper = createWrapper();
+
+      expect(wrapper.find('RadioGroup WithStyles(Button) TextField[defaultValue="1024"]').props().disabled).toBe(true);
+      expect(wrapper.find('RadioGroup WithStyles(Button) TextField[defaultValue="768"]').props().disabled).toBe(true);
+      expect(wrapper.setState({ selectedSize: 'custom' }));
+    });
+
+    it('properly updates the embed code w/ the custom sizes when custom is selected', () => {
+      wrapper = createWrapper();
+
+      expect(wrapper.find('TextField[multiline]').props().value).toMatch(/width="560" height="420"/);
+      wrapper.find('RadioGroup WithStyles(Button)').simulate('click');
+      expect(wrapper.find('TextField[multiline]').props().value).toMatch(/width="1024" height="768"/);
+    });
+
+    it('updates the customSize state when the text fields are updated', () => {
+      wrapper = createWrapper();
+
+      wrapper.find('RadioGroup WithStyles(Button)').simulate('click');
+      wrapper.find('RadioGroup WithStyles(Button) TextField[defaultValue="1024"]').simulate('change', { target: { value: '900' } });
+      expect(wrapper.find('TextField[multiline]').props().value).toMatch(/width="900" height="768"/);
+    });
   });
 });

--- a/src/MiradorShareDialog.js
+++ b/src/MiradorShareDialog.js
@@ -110,6 +110,7 @@ export class MiradorShareDialog extends Component {
       embedUrlReplacePattern,
       manifestId,
       open,
+      windowId,
     } = this.props;
     const { shareLinkText } = this.state;
 
@@ -149,6 +150,7 @@ export class MiradorShareDialog extends Component {
               <MiradorShareEmbed
                 embedUrlReplacePattern={embedUrlReplacePattern}
                 manifestId={manifestId}
+                windowId={windowId}
               />
               <Divider />
             </React.Fragment>
@@ -197,6 +199,7 @@ MiradorShareDialog.propTypes = {
   ),
   manifestId: PropTypes.string,
   open: PropTypes.bool,
+  windowId: PropTypes.string.isRequired,
 };
 
 MiradorShareDialog.defaultProps = {


### PR DESCRIPTION
Closes #9 

_**[WIP]** So @ggeisler can look it over and we can discuss the keyboard access._

<img width="564" alt="Screen Shot 2019-06-11 at 3 56 47 PM" src="https://user-images.githubusercontent.com/96776/59312316-928de580-8c61-11e9-8861-f4d2691082f7.png">

Happy to talk through any of this.  Was trying to aim for keyboard a11y support while maintaining proper inputs/labels (keeping in mind that this may ultimately be better served by a [ToggleButton](https://material-ui.com/components/toggle-button/) from MUI Labs once we've updated to an alpha release of Mirador w/ the updated version)
