### PR TITLE
Don't render the dialog if it's not set to open.

### DIFF
--- a/__tests__/MiradorShareDialog.test.js
+++ b/__tests__/MiradorShareDialog.test.js
@@ -18,11 +18,11 @@ function createWrapper(props) {
 
 describe('Dialog', () => {
   let wrapper;
-  it('renders a dialog that is open/closed based on the passed in prop', () => {
+  it('renders a dialog based on the passed in open prop', () => {
     wrapper = createWrapper();
     expect(wrapper.find('WithStyles(ForwardRef(Dialog))').props().open).toBe(true);
     wrapper = createWrapper({ open: false });
-    expect(wrapper.find('WithStyles(ForwardRef(Dialog))').props().open).toBe(false);
+    expect(wrapper.find('WithStyles(ForwardRef(Dialog))').length).toBe(0);
   });
 
   it('renders the section headings in an h3', () => {

--- a/src/MiradorShareDialog.js
+++ b/src/MiradorShareDialog.js
@@ -113,6 +113,8 @@ export class MiradorShareDialog extends Component {
     } = this.props;
     const { shareLinkText } = this.state;
 
+    if (!open) return (<React.Fragment />);
+
     return (
       <Dialog
         onClose={closeShareDialog}


### PR DESCRIPTION
We do this in the Download plugin as well.  This way the dialog isn't thrown into the window until the user has requested it.