### PR TITLE
Accessibility updates to copy buttons and textarea description

### DIFF
--- a/__tests__/MiradorShareEmbed.test.js
+++ b/__tests__/MiradorShareEmbed.test.js
@@ -18,17 +18,18 @@ function createWrapper(props) {
 describe('MiradorShareEmbed', () => {
   let wrapper;
 
-  it('renders fieldsets w/ legends for each section of the embed component', () => {
+  it('renders fieldsets w/ legends or labels for each section of the embed component', () => {
     wrapper = createWrapper();
 
     expect(wrapper.find('WithStyles(ForwardRef(FormControl))[component="fieldset"]').length).toBe(2);
-    expect(wrapper.find('WithStyles(ForwardRef(FormLabel))[component="legend"]').length).toBe(2);
+    expect(wrapper.find('WithStyles(ForwardRef(FormLabel))').length).toBe(2);
+    expect(wrapper.find('WithStyles(ForwardRef(FormLabel))[component="legend"]').length).toBe(1);
     expect(wrapper.find(
       'WithStyles(ForwardRef(FormLabel))',
     ).at(0).props().children).toEqual('Select viewer size');
     expect(wrapper.find(
       'WithStyles(ForwardRef(FormLabel))',
-    ).at(1).props().children).toEqual('then copy & paste code');
+    ).at(1).props().children).toEqual('Copy & paste code');
   });
 
   it('renders a radio group w/ a form control for each of the size options', () => {

--- a/src/MiradorShareDialog.js
+++ b/src/MiradorShareDialog.js
@@ -149,7 +149,7 @@ export class MiradorShareDialog extends Component {
                 />
                 {' '}
                 <CopyToClipboard text={shareLinkText}>
-                  <Button className={classes.copyButton} variant="outlined" color="primary">Copy</Button>
+                  <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy link">Copy</Button>
                 </CopyToClipboard>
               </div>
               <Divider />

--- a/src/MiradorShareEmbed.js
+++ b/src/MiradorShareEmbed.js
@@ -151,9 +151,10 @@ class MiradorShareEmbed extends Component {
           </RadioGroup>
         </FormControl>
         <FormControl component="fieldset" className={classes.formControl}>
-          <FormLabel component="legend" className={classes.legend}>then copy &amp; paste code</FormLabel>
+          <FormLabel className={classes.label} for="copyCode">Copy &amp; paste code</FormLabel>
           <div className={classes.inputContainer}>
             <TextField
+              id="copyCode"
               fullWidth
               multiline
               rows={4}
@@ -176,6 +177,7 @@ MiradorShareEmbed.propTypes = {
     formControl: PropTypes.string,
     formControlLabel: PropTypes.string,
     legend: PropTypes.string,
+    label: PropTypes.string,
     inputContainer: PropTypes.string,
     radioGroup: PropTypes.string,
     selectedFormControlLabel: PropTypes.string,
@@ -218,6 +220,10 @@ const styles = theme => ({
     },
   },
   legend: {
+    paddingBottom: theme.spacing(),
+    paddingTop: theme.spacing(),
+  },
+  label: {
     paddingBottom: theme.spacing(),
     paddingTop: theme.spacing(),
   },

--- a/src/MiradorShareEmbed.js
+++ b/src/MiradorShareEmbed.js
@@ -161,7 +161,7 @@ class MiradorShareEmbed extends Component {
               variant="filled"
             />
             <CopyToClipboard text={this.embedCode()}>
-              <Button className={classes.copyButton} variant="outlined" color="primary">Copy</Button>
+              <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy code">Copy</Button>
             </CopyToClipboard>
           </div>
         </FormControl>


### PR DESCRIPTION
### Description
An accessibility audit completed at Harvard revealed two issues that occur when screenreaders are interacting with the share plugin.

1. There are two buttons labeled "copy" that copy different info; When seen in context, the placement of these buttons are fine.  Using a screenreader, though, when listing the buttons, there will be two buttons with the same text (copy) that copy different content, thus creating confusion.
2. `textarea` form field (where the embed code is offered for copying and pasting) is not labeled; every form field element should have a descriptive text label.

### Fixes
1. Added aria-labels to the “Copy” buttons so that screen readers can differentiate the two options (copying a link vs. copying the iframe code)
3. Updated the "copy & paste code" element to be a label instead of a legend, so that screenreaders have a clearer description of the textarea form field when it is read aloud; this also involved updating the classname to be a label and giving it the same styles as it had before with the legend. 

Unit tests were also updated to reflect the changes made related to the legend and label components.
