### PR TITLE
Accessibility updates to Alternate viewer section and copy buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Configurations for this plugin are injected when Mirador is initialized under th
 
 | Config Key | Type | Description |
 | --- | --- | --- |
-| `dragAndDropInfoLink` | string/url | Provides a `What is IIIF` link under the Alternate Viewers / Drag & Drop that points to the configured URL. This will also be the base of the Drag & Drop link so that if a user clicks instead of drags, they will go the informational page (as opposed to the manifest which is the default behavior) |
+| `iiifInfoLink` | string/url | Provides a `What is IIIF` link under the Alternate viewer section that points to the configured URL |
 | `embedOption` | object | The configuration objects for the Embed section. You can use this if you're able to easily modify the manifest ID to a URL that can be used to embed the resource in an `<iframe>` (most likely in embedded mode where you're only displaying your own content) |
 | `embedOption.enabled` | boolean | Configure whether to render the Embed section in the Share Dialog. |
 | `embedOption.embedIframeAttributes` | string | A string that contains HTML attributes to be applied to the `<iframe>` embed code. (Default: `allowfullscreen frameborder="0"`) |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Configurations for this plugin are injected when Mirador is initialized under th
 
 | Config Key | Type | Description |
 | --- | --- | --- |
-| `iiifInfoLink` | string/url | Provides a `What is IIIF` link under the Alternate viewer section that points to the configured URL |
+| `iiifInfoLink` | string/url | Provides a `What is IIIF` link under the Add to another viewer section that points to the configured URL |
 | `embedOption` | object | The configuration objects for the Embed section. You can use this if you're able to easily modify the manifest ID to a URL that can be used to embed the resource in an `<iframe>` (most likely in embedded mode where you're only displaying your own content) |
 | `embedOption.enabled` | boolean | Configure whether to render the Embed section in the Share Dialog. |
 | `embedOption.embedIframeAttributes` | string | A string that contains HTML attributes to be applied to the `<iframe>` embed code. (Default: `allowfullscreen frameborder="0"`) |

--- a/__tests__/MiradorShareDialog.test.js
+++ b/__tests__/MiradorShareDialog.test.js
@@ -95,22 +95,13 @@ describe('Dialog', () => {
     });
 
     it('renders the link with IIIF Drag & Drop Compliant URL (passing the manifest in a param)', () => {
-      expect(wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"] WithStyles(ForwardRef(Link))').props().href).toEqual(
-        'http://example.com/abc/iiif/manifest?manifest=http://example.com/abc/iiif/manifest',
-      );
+      const link = wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"] WithStyles(ForwardRef(Link))').at(0);
+      expect(link.props().href).toEqual('http://example.com/abc/iiif/manifest?manifest=http://example.com/abc/iiif/manifest');
     });
 
     describe('when an info link is configured/passed in as a prop', () => {
-      it('renders Drag and Drop link with the passed URL as the base (where users will go if they click)', () => {
-        wrapper = createWrapper({ dragAndDropInfoLink: 'http://iiif.io/' });
-
-        expect(wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"] WithStyles(ForwardRef(Link))').at(0).props().href).toEqual(
-          'http://iiif.io/?manifest=http://example.com/abc/iiif/manifest',
-        );
-      });
-
       it('renders a "What is IIIF" link', () => {
-        wrapper = createWrapper({ dragAndDropInfoLink: 'http://iiif.io/' });
+        wrapper = createWrapper({ iiifInfoLink: 'http://iiif.io/' });
         const link = wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"] WithStyles(ForwardRef(Link))').at(1);
         expect(link.props().children).toEqual('What is IIIF?');
         expect(link.props().href).toEqual('http://iiif.io/');

--- a/__tests__/MiradorShareDialog.test.js
+++ b/__tests__/MiradorShareDialog.test.js
@@ -29,7 +29,7 @@ describe('Dialog', () => {
     wrapper = createWrapper();
     expect(wrapper.find('WithStyles(ForwardRef(Typography))[variant="h3"]').get(0).props.children).toEqual('Share link');
     expect(wrapper.find('WithStyles(ForwardRef(Typography))[variant="h3"]').get(1).props.children).toEqual('Embed');
-    expect(wrapper.find('WithStyles(ForwardRef(Typography))[variant="h3"]').get(2).props.children).toEqual('Alternate viewer');
+    expect(wrapper.find('WithStyles(ForwardRef(Typography))[variant="h3"]').get(2).props.children).toEqual('Add to another viewer');
   });
 
   it('has a close button that calls closeShareDialog on click', () => {
@@ -49,7 +49,7 @@ describe('Dialog', () => {
       wrapper = createWrapper();
 
       expect(wrapper.find('WithStyles(ForwardRef(TextField))').length).toBe(1);
-      expect(wrapper.find('CopyToClipboard WithStyles(ForwardRef(Button))').props().children).toEqual('Copy');
+      expect(wrapper.find('CopyToClipboard WithStyles(ForwardRef(Button))').get(0).props.children).toEqual('Copy');
     });
 
     it('renders the TextField & CopyToClipboard components w/ the shareLinkText state value', () => {
@@ -57,7 +57,7 @@ describe('Dialog', () => {
 
       wrapper.setState({ shareLinkText: 'http://example.com/iiif/manifest' });
       expect(wrapper.find('WithStyles(ForwardRef(TextField))').props().defaultValue).toEqual('http://example.com/iiif/manifest');
-      expect(wrapper.find('CopyToClipboard').props().text).toEqual('http://example.com/iiif/manifest');
+      expect(wrapper.find('CopyToClipboard').get(0).props.text).toEqual('http://example.com/iiif/manifest');
     });
 
     it("sets the component's shareLinkText on TextField change", () => {
@@ -70,7 +70,7 @@ describe('Dialog', () => {
       wrapper = createWrapper({ displayShareLink: false });
 
       expect(wrapper.find('WithStyles(ForwardRef(TextField))').length).toBe(0);
-      expect(wrapper.find('CopyToClipboard').length).toBe(0);
+      expect(wrapper.find('CopyToClipboard').length).toBe(1);
     });
   });
 
@@ -84,25 +84,29 @@ describe('Dialog', () => {
     });
   });
 
-  describe('Alternate viewer section', () => {
-    it('renders a link, icon, and text', () => {
+  describe('Add to another viewer section', () => {
+    it('renders a link, icon, button, and text', () => {
       wrapper = createWrapper();
 
-      expect(wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"] WithStyles(ForwardRef(Link)) IiifIcon').length).toBe(1);
-      expect(wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"]').props().children[1]).toEqual(
-        'Drag & drop this icon to any IIIF viewer.',
+      expect(wrapper.find('WithStyles(ForwardRef(Grid)) WithStyles(ForwardRef(Link)) IiifIcon').length).toBe(1);
+      expect(wrapper.find('WithStyles(ForwardRef(Grid)) CopyToClipboard WithStyles(ForwardRef(Button))').length).toBe(1);
+      expect(wrapper.find('WithStyles(ForwardRef(Grid)) WithStyles(ForwardRef(Typography))[variant="body1"]').get(0).props.children).toEqual(
+        'Drag & drop IIIF icon to add this resource to any IIIF viewer.',
+      );
+      expect(wrapper.find('WithStyles(ForwardRef(Grid)) WithStyles(ForwardRef(Typography))[variant="body1"]').get(2).props.children).toEqual(
+        'Copy & paste the resource\'s manifest into any IIIF viewer.',
       );
     });
 
     it('renders the link with IIIF Drag & Drop Compliant URL (passing the manifest in a param)', () => {
-      const link = wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"] WithStyles(ForwardRef(Link))').at(0);
+      const link = wrapper.find('WithStyles(ForwardRef(Grid)) WithStyles(ForwardRef(Link))').at(0);
       expect(link.props().href).toEqual('http://example.com/abc/iiif/manifest?manifest=http://example.com/abc/iiif/manifest');
     });
 
     describe('when an info link is configured/passed in as a prop', () => {
       it('renders a "What is IIIF" link', () => {
         wrapper = createWrapper({ iiifInfoLink: 'http://iiif.io/' });
-        const link = wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"] WithStyles(ForwardRef(Link))').at(1);
+        const link = wrapper.find('WithStyles(ForwardRef(Typography))[variant="body1"] WithStyles(ForwardRef(Link))');
         expect(link.props().children).toEqual('What is IIIF?');
         expect(link.props().href).toEqual('http://iiif.io/');
       });

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -7,7 +7,7 @@ const config = {
     loadedManifest: 'https://purl.stanford.edu/sn904cj3429/iiif/manifest',
   }],
   miradorSharePlugin: {
-    dragAndDropInfoLink: 'https://iiif.io',
+    iiifInfoLink: 'https://iiif.io',
     embedOption: {
       enabled: true,
       embedUrlReplacePattern: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirador-share-plugin",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "mirador-share-plugin React component",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },
-  "dependencies": {},
+  "dependencies": {
+    "notistack": "^3.0.1"
+  },
   "peerDependencies": {
     "@material-ui/core": "^4.7.2",
     "@material-ui/icons": "^4.5.1",

--- a/src/MiradorShareDialog.js
+++ b/src/MiradorShareDialog.js
@@ -150,7 +150,11 @@ export class MiradorShareDialog extends Component {
                 />
                 {' '}
                 <CopyToClipboard text={shareLinkText}>
-                  <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy link to clipboard" onClick={() => enqueueSnackbar(('Link copied to clipboard!'), { variant: 'success' })}>Copy</Button>
+                  <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy link to clipboard" onClick={() => enqueueSnackbar((
+                    <Typography variant="body1">
+                      Link copied to clipboard!
+                    </Typography>
+                  ), { variant: 'success' })}>Copy</Button>
                 </CopyToClipboard>
               </div>
               <Divider />
@@ -187,7 +191,11 @@ export class MiradorShareDialog extends Component {
                 Copy & paste the resource&apos;s manifest into any IIIF viewer.
               </Typography>
               <CopyToClipboard text={this.dragAndDropUrl()}>
-                <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy manifest to clipboard" onClick={() => enqueueSnackbar(('Manifest copied to clipboard!'), { variant: 'success' })}>Copy</Button>
+                <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy manifest to clipboard" onClick={() => enqueueSnackbar((
+                  <Typography variant="body1">
+                    Manifest copied to clipboard!
+                  </Typography>
+                ), { variant: 'success' })}>Copy</Button>
               </CopyToClipboard>
             </Grid>
           </Grid>

--- a/src/MiradorShareDialog.js
+++ b/src/MiradorShareDialog.js
@@ -34,7 +34,7 @@ const mapStateToProps = (state, { windowId }) => {
     embedIframeTitle: embedOption.embedIframeTitle,
     manifestIdReplacePattern: miradorSharePluginConfig.shareLink
       && miradorSharePluginConfig.shareLink.manifestIdReplacePattern,
-    dragAndDropInfoLink: miradorSharePluginConfig.dragAndDropInfoLink,
+    iiifInfoLink: miradorSharePluginConfig.iiifInfoLink,
     manifestId: (getManifestoInstance(state, { windowId }) || {}).id,
     open: (state.windowDialogs[windowId] && state.windowDialogs[windowId].openDialog === 'share'),
     syncIframeDimensions: embedOption.syncIframeDimensions,
@@ -63,28 +63,22 @@ export class MiradorShareDialog extends Component {
   }
 
   dragAndDropUrl() {
-    const { dragAndDropInfoLink, manifestId } = this.props;
-    let baseUrl;
-
-    baseUrl = manifestId;
-
-    if (dragAndDropInfoLink) {
-      baseUrl = dragAndDropInfoLink;
-    }
+    const { manifestId } = this.props;
+    const baseUrl = manifestId;
 
     return `${baseUrl}?manifest=${manifestId}`;
   }
 
   whatIsThisLink() {
-    const { dragAndDropInfoLink } = this.props;
+    const { iiifInfoLink } = this.props;
 
-    if (!dragAndDropInfoLink) return null;
+    if (!iiifInfoLink) return null;
 
     return (
       <React.Fragment>
         {' '}
         [
-        <Link href={dragAndDropInfoLink}>What is IIIF?</Link>
+        <Link href={iiifInfoLink}>What is IIIF?</Link>
         ]
       </React.Fragment>
     );
@@ -149,7 +143,7 @@ export class MiradorShareDialog extends Component {
                 />
                 {' '}
                 <CopyToClipboard text={shareLinkText}>
-                  <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy link">Copy</Button>
+                  <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy link to clipboard">Copy</Button>
                 </CopyToClipboard>
               </div>
               <Divider />
@@ -201,7 +195,7 @@ MiradorShareDialog.propTypes = {
   containerId: PropTypes.string.isRequired,
   displayEmbedOption: PropTypes.bool,
   displayShareLink: PropTypes.bool,
-  dragAndDropInfoLink: PropTypes.string,
+  iiifInfoLink: PropTypes.string,
   embedIframeAttributes: PropTypes.string,
   embedIframeTitle: PropTypes.string,
   embedUrlReplacePattern: PropTypes.arrayOf(
@@ -227,7 +221,7 @@ MiradorShareDialog.propTypes = {
 MiradorShareDialog.defaultProps = {
   displayEmbedOption: false,
   displayShareLink: false,
-  dragAndDropInfoLink: null,
+  iiifInfoLink: 'https://iiif.io',
   embedIframeAttributes: 'allowfullscreen frameborder="0"',
   embedIframeTitle: 'Image viewer',
   embedUrlReplacePattern: [],
@@ -252,6 +246,7 @@ const styles = theme => ({
   },
   iiifIcon: {
     verticalAlign: 'text-bottom',
+    cursor: 'move',
   },
   inputContainer: {
     alignItems: 'flex-end',

--- a/src/MiradorShareDialog.js
+++ b/src/MiradorShareDialog.js
@@ -9,7 +9,9 @@ import Divider from '@material-ui/core/Divider';
 import Link from '@material-ui/core/Link';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { SnackbarProvider, enqueueSnackbar } from 'notistack';
 import { getManifestoInstance } from 'mirador/dist/es/src/state/selectors/manifests';
 import { getContainerId } from 'mirador/dist/es/src/state/selectors/config';
 import ScrollIndicatedDialogContent from 'mirador/dist/es/src/containers/ScrollIndicatedDialogContent';
@@ -77,9 +79,7 @@ export class MiradorShareDialog extends Component {
     return (
       <React.Fragment>
         {' '}
-        [
         <Link href={iiifInfoLink}>What is IIIF?</Link>
-        ]
       </React.Fragment>
     );
   }
@@ -129,6 +129,13 @@ export class MiradorShareDialog extends Component {
             Share
           </Typography>
         </DialogTitle>
+        <SnackbarProvider
+          maxSnack={1}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+        />
         <ScrollIndicatedDialogContent>
           {displayShareLink && (
             <React.Fragment>
@@ -143,7 +150,7 @@ export class MiradorShareDialog extends Component {
                 />
                 {' '}
                 <CopyToClipboard text={shareLinkText}>
-                  <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy link to clipboard">Copy</Button>
+                  <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy link to clipboard" onClick={() => enqueueSnackbar(('Link copied to clipboard!'), { variant: 'success' })}>Copy</Button>
                 </CopyToClipboard>
               </div>
               <Divider />
@@ -162,14 +169,29 @@ export class MiradorShareDialog extends Component {
               <Divider />
             </React.Fragment>
           )}
-          <Typography className={classes.h3} variant="h3">Alternate viewer</Typography>
-          <Typography variant="body1">
-            <Link href={this.dragAndDropUrl()} className={classes.iiifLink}>
-              <IiiifIcon className={classes.iiifIcon} />
-            </Link>
-            Drag & drop this icon to any IIIF viewer.
-            {this.whatIsThisLink()}
-          </Typography>
+          <Typography className={classes.h3} variant="h3">Add to another viewer</Typography>
+          <Grid container spacing={1} className={classes.grid}>
+            <Grid item xs>
+              <Typography variant="body1">
+                Drag & drop IIIF icon to add this resource to any IIIF viewer.
+              </Typography>
+              <Link href={this.dragAndDropUrl()} className={classes.iiifLink}>
+                <IiiifIcon className={classes.iiifIcon} />
+              </Link>
+            </Grid>
+            <Grid item xs={1}>
+              <Typography variant="body1">or</Typography>
+            </Grid>
+            <Grid item xs>
+              <Typography variant="body1">
+                Copy & paste the resource&apos;s manifest into any IIIF viewer.
+              </Typography>
+              <CopyToClipboard text={this.dragAndDropUrl()}>
+                <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy manifest to clipboard" onClick={() => enqueueSnackbar(('Manifest copied to clipboard!'), { variant: 'success' })}>Copy</Button>
+              </CopyToClipboard>
+            </Grid>
+          </Grid>
+          <Typography variant="body1">{this.whatIsThisLink()}</Typography>
         </ScrollIndicatedDialogContent>
         <DialogActions>
           <Button onClick={closeShareDialog} color="primary">
@@ -190,6 +212,7 @@ MiradorShareDialog.propTypes = {
     iiifLink: PropTypes.string,
     inputContainer: PropTypes.string,
     shareLinkInput: PropTypes.string,
+    grid: PropTypes.string,
   }).isRequired,
   closeShareDialog: PropTypes.func.isRequired,
   containerId: PropTypes.string.isRequired,
@@ -246,7 +269,8 @@ const styles = theme => ({
   },
   iiifIcon: {
     verticalAlign: 'text-bottom',
-    cursor: 'move',
+    cursor: 'grab',
+    paddingTop: '12px',
   },
   inputContainer: {
     alignItems: 'flex-end',
@@ -255,6 +279,10 @@ const styles = theme => ({
     marginBottom: theme.spacing(),
   },
   shareLinkInput: {
+    paddingTop: '12px',
+  },
+  grid: {
+    textAlign: 'center',
     paddingTop: '12px',
   },
 });

--- a/src/MiradorShareDialog.js
+++ b/src/MiradorShareDialog.js
@@ -150,11 +150,19 @@ export class MiradorShareDialog extends Component {
                 />
                 {' '}
                 <CopyToClipboard text={shareLinkText}>
-                  <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy link to clipboard" onClick={() => enqueueSnackbar((
-                    <Typography variant="body1">
-                      Link copied to clipboard!
-                    </Typography>
-                  ), { variant: 'success' })}>Copy</Button>
+                  <Button
+                    className={classes.copyButton}
+                    variant="outlined"
+                    color="primary"
+                    aria-label="Copy link to clipboard"
+                    onClick={() => enqueueSnackbar((
+                      <Typography variant="body1">
+                        Link copied to clipboard!
+                      </Typography>
+                    ), { variant: 'success' })}
+                  >
+                    Copy
+                  </Button>
                 </CopyToClipboard>
               </div>
               <Divider />
@@ -191,11 +199,19 @@ export class MiradorShareDialog extends Component {
                 Copy & paste the resource&apos;s manifest into any IIIF viewer.
               </Typography>
               <CopyToClipboard text={this.dragAndDropUrl()}>
-                <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy manifest to clipboard" onClick={() => enqueueSnackbar((
-                  <Typography variant="body1">
-                    Manifest copied to clipboard!
-                  </Typography>
-                ), { variant: 'success' })}>Copy</Button>
+                <Button
+                  className={classes.copyButton}
+                  variant="outlined"
+                  color="primary"
+                  aria-label="Copy manifest to clipboard"
+                  onClick={() => enqueueSnackbar((
+                    <Typography variant="body1">
+                      Manifest copied to clipboard!
+                    </Typography>
+                  ), { variant: 'success' })}
+                >
+                  Copy
+                </Button>
               </CopyToClipboard>
             </Grid>
           </Grid>

--- a/src/MiradorShareEmbed.js
+++ b/src/MiradorShareEmbed.js
@@ -8,6 +8,7 @@ import FormLabel from '@material-ui/core/FormLabel';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { SnackbarProvider, enqueueSnackbar } from 'notistack';
 import EmbedSizeIcon from './EmbedSizeIcon';
@@ -170,7 +171,11 @@ class MiradorShareEmbed extends Component {
               variant="filled"
             />
             <CopyToClipboard text={this.embedCode()}>
-              <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy code to clipboard" onClick={() => enqueueSnackbar(('Code copied to clipboard!'), { variant: 'success' })}>Copy</Button>
+              <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy code to clipboard" onClick={() => enqueueSnackbar((
+                <Typography variant="body1">
+                  Code copied to clipboard!
+                </Typography>
+              ), { variant: 'success' })}>Copy</Button>
             </CopyToClipboard>
           </div>
         </FormControl>

--- a/src/MiradorShareEmbed.js
+++ b/src/MiradorShareEmbed.js
@@ -9,6 +9,7 @@ import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import TextField from '@material-ui/core/TextField';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { SnackbarProvider, enqueueSnackbar } from 'notistack';
 import EmbedSizeIcon from './EmbedSizeIcon';
 
 /**
@@ -139,6 +140,13 @@ class MiradorShareEmbed extends Component {
 
     return (
       <React.Fragment>
+        <SnackbarProvider
+          maxSnack={1}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+        />
         <FormControl component="fieldset" className={classes.formControl}>
           <FormLabel component="legend" className={classes.legend}>Select viewer size</FormLabel>
           <RadioGroup
@@ -162,7 +170,7 @@ class MiradorShareEmbed extends Component {
               variant="filled"
             />
             <CopyToClipboard text={this.embedCode()}>
-              <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy code to clipboard">Copy</Button>
+              <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy code to clipboard" onClick={() => enqueueSnackbar(('Code copied to clipboard!'), { variant: 'success' })}>Copy</Button>
             </CopyToClipboard>
           </div>
         </FormControl>

--- a/src/MiradorShareEmbed.js
+++ b/src/MiradorShareEmbed.js
@@ -171,11 +171,19 @@ class MiradorShareEmbed extends Component {
               variant="filled"
             />
             <CopyToClipboard text={this.embedCode()}>
-              <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy code to clipboard" onClick={() => enqueueSnackbar((
-                <Typography variant="body1">
-                  Code copied to clipboard!
-                </Typography>
-              ), { variant: 'success' })}>Copy</Button>
+              <Button
+                className={classes.copyButton}
+                variant="outlined"
+                color="primary"
+                aria-label="Copy code to clipboard"
+                onClick={() => enqueueSnackbar((
+                  <Typography variant="body1">
+                    Code copied to clipboard!
+                  </Typography>
+                ), { variant: 'success' })}
+              >
+                Copy
+              </Button>
             </CopyToClipboard>
           </div>
         </FormControl>

--- a/src/MiradorShareEmbed.js
+++ b/src/MiradorShareEmbed.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createMuiTheme, withStyles } from '@material-ui/core/styles';
+import { createTheme, withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -62,7 +62,7 @@ class MiradorShareEmbed extends Component {
     const { classes } = this.props;
     const { selectedSize } = this.state;
     const sizes = MiradorShareEmbed.sizes();
-    const iconColor = createMuiTheme().palette.grey[500];
+    const iconColor = createTheme().palette.grey[500];
     const icon = (width, height) => (
       <EmbedSizeIcon
         fillColor={iconColor}
@@ -162,7 +162,7 @@ class MiradorShareEmbed extends Component {
               variant="filled"
             />
             <CopyToClipboard text={this.embedCode()}>
-              <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy code">Copy</Button>
+              <Button className={classes.copyButton} variant="outlined" color="primary" aria-label="Copy code to clipboard">Copy</Button>
             </CopyToClipboard>
           </div>
         </FormControl>

--- a/src/miradorSharePlugin.js
+++ b/src/miradorSharePlugin.js
@@ -32,8 +32,8 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
 });
 
 const mapStateToProps = (state, { windowId }) => ({
-  dragAndDropInfoLink: state.config.miradorSharePlugin
-    && state.config.miradorSharePlugin.dragAndDropInfoLink,
+  iiifInfoLink: state.config.miradorSharePlugin
+    && state.config.miradorSharePlugin.iiifInfoLink,
   manifestId: getManifestoInstance(state, { windowId }).id,
 });
 


### PR DESCRIPTION
## Description
An accessibility audit completed at Harvard revealed two issues that occur when screenreaders are interacting with the share plugin.

1. The small IIIF logo image is a link that a user can click on (which brings up the iiif.co website) OR drag into another viewer instance (to quickly load a new object into the canvas). 
   - None of this is explained to a user relying on assistive technology.
   - The two behaviors (clicking vs. dragging) have different destinations, which can be confusing to any user.
   - The current instructions provided is also not intuitive, especially for novice users.
2. There is no visual or audio cue when a "Copy" button has been clicked; a user is left guessing whether or not the information has been copied to the clipboard (so this is both an accessibility and a usability concern).

## Fixes

1. Update the IIIF icon href to point directly to the manifest (instead of going to the iiif.co homepage on click,  the current default behavior); there is still the option to add a reference to the iiif.co page with the "What if IIIF?" link (which is included by default)
2. Add an alternative interaction where the manifest can be copied to clipboard using the same "Copy" button pattern as the other sections (this is a clear and easy alternative to the cursor/touch-only affordance of the click & drag IIIF icon and satisfies accessibility concerns)
4. Add both an audio and visual cue that "Copy" buttons have been clicked (this should be applied to all three "copy to clipboard" buttons)
5. Update the "Alternative viewer" section to have a clearer title and instructions (see screenshot of new language and layout).

## How should this be tested?
* Spin up the demo site from this branch: `npm run start`
* Visually check to see that the share modal window matches that shown in the screenshot below
* Click on each "copy" button and see that a notification window is triggered in the top center (it should have a green background, with a success icon and message that says "Link/Code/Manifest copied to clipboard!")
* Click and drag the IIIF icon into another viewer instance to ensure that functionality is still working and opens up the image in the new viewer space
* Click on the "What is IIIF?" link to ensure that is still working and brings you to the IIIF.io homepage.

Unit tests were also updated to reflect the changes made related to the legend and label components: `npm run test`

![mirador-share-plugin-update](https://github.com/ProjectMirador/mirador-share-plugin/assets/13121501/654d759e-fa1d-4432-9a06-52d0c57eea11)