### PR TITLE
Add paths to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "dist"
   ],
   "exports": {
-    "./src": "./src/index.js"
+    "./src": "./src/index.js",
+    ".": {
+        "import": "./dist/mirador-share-plugin.es.js",
+        "require": "./dist/mirador-share-plugin.js"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We did this in other plugins.

Prevents:
```
ERROR in ./app/javascript/src/modules/m3_viewer.js 7:0-84
14:59:57 js.1     | Module not found: Error: Package path . is not exported from package /Users/mlongley/Projects/sul-embed/node_modules/mirador-share-plugin (see exports field in /Users/mlongley/Projects/sul-embed/node_modules/mirador-share-plugin/package.json)
```

 I guess we will need alpha.3 for this!