### PR TITLE
Change syntax for externalizing peer dependencies

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -40,7 +40,13 @@ export default defineConfig({
           name: 'MiradorSharePlugin',
         },
         rollupOptions: {
-          external: [...Object.keys(pkg.peerDependencies || {}), '__tests__/*', '__mocks__/*'],
+          external: (id, parentId) => {
+            const peers = Object.keys(pkg.peerDependencies);
+            return peers.indexOf(id) > -1
+              || peers.find((peer) => id.startsWith(`${peer}/`))
+              || id.startsWith('__tests__/')
+              || id.startsWith('__mocks__/');
+          },
           output: {
             assetFileNames: 'mirador-share-plugin.[ext]',
             globals: {


### PR DESCRIPTION
This PR adopts the rollup option changes from ProjectMirador/mirador#4142 / ProjectMirador/mirador#4139 for this repo.